### PR TITLE
installation step, library require step, minor editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,20 @@ Well. The gem is just a [elegant][ref_link] monkeyPatch of Object and Class clas
 And it does types.   
 So... MonkeyTypes!
 
+# Installation
+```
+gem install monkey_type
+```
+
 # Usage
 well. I tried to simplify the usage as hard as i can.   
 There is just two new things
 to learn. the method *#is* and the class macro *contract*.   
 the method is used like this:   
-(remember to write **using MonkeyType**)
+(remember to write **require 'monkey_type'**)
 
 ```ruby
-using MonkeyType
+require 'monkey_type'
 
 def accepts_only_nums(num)
   num.is Numeric
@@ -31,13 +36,13 @@ end
 ```
 
 
-the method is will raise an exception if num don't are numeric or somenthing like numeric.
+the method is will raise an exception if num isn't numeric or something like numeric.
 Remember, we are duck typing here.
 Simple isn't it?
 
 
 ```ruby
-using MonkeyType
+require 'monkey_type'
 
 class Returner
   def return1

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ well. I tried to simplify the usage as hard as i can.
 There is just two new things
 to learn. the method *#is* and the class macro *contract*.   
 the method is used like this:   
-(remember to write **require 'monkey_type'**)
+(remember to you need both 'require' and 'using' lines!)
 
 ```ruby
 require 'monkey_type'
+using MonkeyType
 
 def accepts_only_nums(num)
   num.is Numeric
@@ -36,13 +37,18 @@ end
 ```
 
 
-the method is will raise an exception if num isn't numeric or something like numeric.
+the method is will raise an exception in the form of:
+```
+error: String is not an Numeric (TypeError)
+```
+if `accepts_only_nums` is called and num isn't numeric or something like numeric.
 Remember, we are duck typing here.
 Simple isn't it?
 
 
 ```ruby
 require 'monkey_type'
+using MonkeyType
 
 class Returner
   def return1
@@ -83,7 +89,12 @@ class Booled
   contract :i_return_true_or_false, boolean
 end
 ```
-that is all.    
+that is all.
+
+# Running in irb
+
+The interactive ruby interpreter `irb` is unable to handle `using` modules in the method
+required by monkey_type.  This is a known limitation.  See [Stack Overflow][irb_so] for more details.
 
 # Contributing
 If you want to help focus on the method is_duck? and how to make easier to add
@@ -94,3 +105,4 @@ Just send Pull Requests.
 [logo]: https://upload.wikimedia.org/wikipedia/commons/9/93/Typing_monkey_768px.png
 [matz_link]: https://www.omniref.com/blog/2014/11/17/matz-at-rubyconf-2014-will-ruby-3-dot-0-be-statically-typed/
 [ref_link]: http://ruby-doc.org/core-2.1.1/doc/syntax/refinements_rdoc.html
+[irb_so]: http://stackoverflow.com/questions/34620550/why-did-i-get-main-using-is-permitted-only-at-toplevel-when-i-used-a-refinemen/34627153#34627153


### PR DESCRIPTION
Added an installation heading to explain the `gem install` command required to install the library.

Updated the instructions for `using` the library to a statement that works for Ruby 2.3.0.
